### PR TITLE
bumping activesupport/model dependencies

### DIFF
--- a/credit_card_validations.gemspec
+++ b/credit_card_validations.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
 
-  gem.add_dependency "activemodel", ">= 3", "<= 6.1"
-  gem.add_dependency "activesupport", ">= 3", "<= 6.1"
+  gem.add_dependency "activemodel", ">= 3", "<= 6.2"
+  gem.add_dependency "activesupport", ">= 3", "<= 6.2"
 
 
   gem.add_development_dependency "mocha", '1.1.0'


### PR DESCRIPTION
We need update Rails version to >= 6.1.3.2 on Authorizer and the specified version is blocking the update.